### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,10 @@
 name: Codecov
 
+permissions:
+  contents: read
+  actions: read
+  secrets: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/oc-2/app/security/code-scanning/3](https://github.com/oc-2/app/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the steps in the workflow, the following permissions are needed:
- `contents: read` for checking out the code and accessing repository files.
- `actions: read` for using GitHub Actions.
- `secrets: read` for accessing the `CODECOV_TOKEN` secret.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as none of the jobs have specific permission requirements beyond these.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
